### PR TITLE
Fully automated installation for K8S node.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 .PHONY: docker
 
 ifndef VERSION
-VERSION := 8
+VERSION := 9
 endif
 
 docker_check:

--- a/builds/any/rootfs/stretch/common/all-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/all-base-packages.yml
@@ -78,3 +78,12 @@
 - strace
 - sysstat
 - ipmitool
+- apt-transport-https
+- ca-certificates
+- curl
+- gnupg2
+- software-properties-common
+- libseccomp2
+- iptables
+- dmsetup
+- libdevmapper1.02.1

--- a/builds/any/rootfs/stretch/common/all-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/all-base-packages.yml
@@ -64,7 +64,6 @@
 - realpath
 - iptables
 - onl-faultd
-- onlp-snmpd
 - oom-shim
 - python-parted
 - python-yaml

--- a/builds/any/rootfs/stretch/common/all-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/all-base-packages.yml
@@ -86,3 +86,4 @@
 - iptables
 - dmsetup
 - libdevmapper1.02.1
+- dbus

--- a/builds/any/rootfs/stretch/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/amd64-base-packages.yml
@@ -13,3 +13,6 @@
 - onl-kernel-4.14-lts-x86-64-all-modules
 - efibootmgr
 - gdisk
+- docker-ce
+- docker-ce-cli
+- containerd

--- a/builds/any/rootfs/stretch/standard/standard.yml
+++ b/builds/any/rootfs/stretch/standard/standard.yml
@@ -24,7 +24,7 @@ Multistrap:
     noauth: true
     explicitsuite: false
     unpack: true
-    debootstrap: Debian-Local Local-All Local-Arch ONL-Local
+    debootstrap: Debian-Local Local-All Local-Arch ONL-Local Docker
     aptsources: Debian ONL
 
   Debian:
@@ -60,6 +60,15 @@ Multistrap:
   Local-Arch:
     source: ${ONLPM_OPTION_REPO}/${ONL_DEBIAN_SUITE}/packages/binary-${ARCH}
     omitdebsrc: true
+
+  Docker:
+    packages: *Packages
+    source: http://${APT_CACHE}apt.opennetlinux.org/debian
+    source: https://download.docker.com/linux/debian/
+    suite: stretch
+    omitdebsrc: true
+    components: stable
+
 
 Configure:
   overlays:
@@ -107,9 +116,6 @@ Configure:
       platforms : $PLATFORM_LIST
 
   issue: $VERSION_STRING
-  commands:
-    - 'curl -fsSL https://get.docker.com -o /tmp/get-docker.sh'
-    - 'sudo sh /tmp/get-docker.sh'
 
   files:
     remove:

--- a/builds/any/rootfs/stretch/standard/standard.yml
+++ b/builds/any/rootfs/stretch/standard/standard.yml
@@ -107,6 +107,9 @@ Configure:
       platforms : $PLATFORM_LIST
 
   issue: $VERSION_STRING
+  commands:
+    - 'curl -fsSL https://get.docker.com -o /tmp/get-docker.sh'
+    - 'sudo sh /tmp/get-docker.sh'
 
   files:
     remove:

--- a/tools/onlrfs.py
+++ b/tools/onlrfs.py
@@ -495,7 +495,7 @@ rm -f /usr/sbin/policy-rc.d
                     lines = open(config).readlines()
                     with open(config, "w") as f:
                         for line in lines:
-                            if line.startswith('PermitRootLogin'):
+                            if 'PermitRootLogin' in line:
                                 v = options['PermitRootLogin']
                                 logger.info("Setting PermitRootLogin to %s" % v)
                                 f.write('PermitRootLogin %s\n' % v)
@@ -691,7 +691,7 @@ if __name__ == '__main__':
         lines = open(config).readlines()
         with open(config, "w") as f:
             for line in lines:
-                if line.startswith('PermitRootLogin'):
+                if 'PermitRootLogin' in line:
                     v = "Yes"
                     logger.info("Setting PermitRootLogin to %s" % v)
                     f.write('PermitRootLogin %s\n' % v)


### PR DESCRIPTION
- Install all required packages
- Fixed the `PermitRootLogin` option in sshd_config, default string starts with `#`.
- Add the docker deb and then install docker-ce/docker-ce-cli/containerd
- Bump default Debian version from 8 to 9.