### PR TITLE
Use DHCP as the default approach to configure network

### DIFF
--- a/builds/amd64/installer/installed/builds/boot-config
+++ b/builds/amd64/installer/installed/builds/boot-config
@@ -1,4 +1,3 @@
 NETDEV=ma1
-NETAUTO=dhcp
 BOOTMODE=INSTALLED
 SWI=images::latest

--- a/builds/amd64/installer/swi/builds/boot-config
+++ b/builds/amd64/installer/swi/builds/boot-config
@@ -1,4 +1,3 @@
 NETDEV=ma1
-NETAUTO=dhcp
 BOOTMODE=SWI
 SWI=images::latest

--- a/builds/any/rootfs/stretch/common/overlay/etc/network/interfaces.d/ma1
+++ b/builds/any/rootfs/stretch/common/overlay/etc/network/interfaces.d/ma1
@@ -1,0 +1,2 @@
+auto ma1 
+iface ma1 inet dhcp


### PR DESCRIPTION
Follow the Debian style to config the network instead of the boot-config style.

DHCP in boot-config can get the IP address but not the DNS name servers, so decide to get rid of it.